### PR TITLE
#623 fix nomenclatura javascript

### DIFF
--- a/Sorgenti Client/PortaleRegione.Client/PortaleRegione.Client/Views/Emendamenti/RiepilogoEM.cshtml
+++ b/Sorgenti Client/PortaleRegione.Client/PortaleRegione.Client/Views/Emendamenti/RiepilogoEM.cshtml
@@ -179,6 +179,13 @@
 
                 checkSelectedEM();
             });
+
+        function viewStandard() {
+            $('#btnSearch').show();
+            $('#pnlViewStandard').show();
+            $('#pnlViewTestoAtto').hide();
+            $('#pnlOrdinamento').hide();
+        }
         
         function filtra() {
             setTimeout(function() {

--- a/Sorgenti Client/PortaleRegione.Client/PortaleRegione.Client/Views/Emendamenti/_OrdinamentoAttoScript.cshtml
+++ b/Sorgenti Client/PortaleRegione.Client/PortaleRegione.Client/Views/Emendamenti/_OrdinamentoAttoScript.cshtml
@@ -2,7 +2,7 @@
 
 <script>
 
-    var template_item = "<li class='collection-item' data-uidem='{{UIDEM}}'>{{N_EM}} <a class='secondary-content blue-text' onclick=\"openMetaDati(\'{{UIDEM}}\')\"'><i class='material-icons'>edit</i></li>";
+    var template_item_ordinamento_atto = "<li class='collection-item' data-uidem='{{UIDEM}}'>{{N_EM}} <a class='secondary-content blue-text' onclick=\"openMetaDati(\'{{UIDEM}}\')\"'><i class='material-icons'>edit</i></li>";
     var template_item_pos = "<li class='collection-item'>{{POS}}</li>";
 
     async function viewOrdinamentoAtto() {
@@ -26,7 +26,7 @@
 
         $.each(grigliaInDb,
             function(index, em) {
-                var template_item_em = template_item.replace(/{{N_EM}}/g, em.N_EM)
+                var template_item_em = template_item_ordinamento_atto.replace(/{{N_EM}}/g, em.N_EM)
                     .replace(/{{UIDEM}}/g, em.UIDEM);
                 var template_item_em_pos = template_item_pos.replace(/{{POS}}/g, em.OrdineVotazione);
                 table.append(template_item_em);

--- a/Sorgenti Client/PortaleRegione.Client/PortaleRegione.Client/Views/Emendamenti/_TestiAttoScript.cshtml
+++ b/Sorgenti Client/PortaleRegione.Client/PortaleRegione.Client/Views/Emendamenti/_TestiAttoScript.cshtml
@@ -2,7 +2,7 @@
 
 <script>
 
-    var template_item = "<div class='chip white black-text hoverable' style='min-width: unset; border: 1px solid green' onclick=\"goToEM(\'{{UIDEM}}\')\"><b>{{N_EM}}</b> - {{DisplayName}}</div>";
+    var template_item_testo_atto = "<div class='chip white black-text hoverable' style='min-width: unset; border: 1px solid green' onclick=\"goToEM(\'{{UIDEM}}\')\"><b>{{N_EM}}</b> - {{DisplayName}}</div>";
 
     async function viewTestoAtto() {
         waiting(true);
@@ -25,11 +25,9 @@
                 var testoArticolo = articoloModel.Data.TestoArticolo ? articoloModel.Data.TestoArticolo : "";
                 var emArticoli = "";
                 if (articoloModel.Emendamenti.length > 0) {
-                    emArticoli = "<br>";
-
                     $.each(articoloModel.Emendamenti,
                         function(index, emArtItem) {
-                            var template_item_em = template_item.replace(/{{UIDEM}}/g, emArtItem.UID_QRCode)
+                            var template_item_em = template_item_testo_atto.replace(/{{UIDEM}}/g, emArtItem.UID_QRCode)
                                 .replace(/{{N_EM}}/g, emArtItem.N_EM)
                                 .replace(/{{DisplayName}}/g, emArtItem.PersonaProponente.DisplayName);
                             emArticoli = emArticoli + template_item_em;
@@ -42,11 +40,9 @@
                             var testoComma = commaModel.Data.TestoComma ? commaModel.Data.TestoComma : "";
                             var emCommi = "";
                             if (commaModel.Emendamenti.length > 0) {
-                                emCommi = "<br>";
-
                                 $.each(commaModel.Emendamenti,
                                     function(index, emCommaItem) {
-                                        var template_item_em = template_item.replace(/{{UIDEM}}/g, emCommaItem.UID_QRCode)
+                                        var template_item_em = template_item_testo_atto.replace(/{{UIDEM}}/g, emCommaItem.UID_QRCode)
                                             .replace(/{{N_EM}}/g, emCommaItem.N_EM)
                                             .replace(/{{DisplayName}}/g, emCommaItem.PersonaProponente.DisplayName);
 
@@ -61,11 +57,9 @@
                                         var testoLettera = letteraModel.Data.TestoLettera ? letteraModel.Data.TestoLettera : "";
                                         var emLettere = "";
                                         if (letteraModel.Emendamenti.length > 0) {
-                                            emLettere = "<br>";
-
                                             $.each(letteraModel.Emendamenti,
                                                 function(index, emLetteraItem) {
-                                                    var template_item_em = template_item.replace(/{{UIDEM}}/g, emLetteraItem.UID_QRCode)
+                                                    var template_item_em = template_item_testo_atto.replace(/{{UIDEM}}/g, emLetteraItem.UID_QRCode)
                                                         .replace(/{{N_EM}}/g, emLetteraItem.N_EM)
                                                         .replace(/{{DisplayName}}/g, emLetteraItem.PersonaProponente.DisplayName);
                                                     emLettere = emLettere + template_item_em;


### PR DESCRIPTION
Nel client il template_item dell'ordinamento atto sovrascriveva il template del testo atto causando l'errore 